### PR TITLE
don't attempt to run `selinuxenabled` if it doesn't exist

### DIFF
--- a/recipes/disabled.rb
+++ b/recipes/disabled.rb
@@ -22,6 +22,7 @@ execute "disable selinux enforcement" do
   only_if "which selinuxenabled && selinuxenabled"
   command "setenforce 0"
   action :run
+  notifies :create, "template[/etc/selinux/config]"
 end
 
 template "/etc/selinux/config" do
@@ -30,4 +31,5 @@ template "/etc/selinux/config" do
     :selinux => "disabled",
     :selinuxtype => "targeted"
   )
+  action :nothing
 end


### PR DESCRIPTION
Fix the issue described in [COOK-1277](http://tickets.opscode.com/browse/COOK-1277), e.g., for Amazon Linux
