### PR TITLE
If SELinux is currently disabled, setenforce will fail

### DIFF
--- a/recipes/enforcing.rb
+++ b/recipes/enforcing.rb
@@ -19,7 +19,7 @@
 #
 
 execute "enable selinux enforcement" do
-  not_if "getenforce | grep -qx 'Enforcing'"
+  not_if "getenforce | egrep -qx 'Enforcing|Disabled'"
   command "setenforce 1"
   action :run
 end


### PR DESCRIPTION
COOK-2124: selinux::enforcing will no longer try to call setenforce if it is currently disabled.
