### PR TITLE
[COOK-4218] Support setting SELinux boolean values

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Node Attributes
   The state to set  by default, to match the default SELinux state on
   RHEL. Can be "enforcing", "permissive", "disabled"
 
+* `node['selinux']['booleans']` - A hash of SELinux boolean names and the
+  values they should be set to. Values can be off, false, or 0 to disable;
+  or on, true, or 1 to enable.
+
 Resources/Providers
 ===================
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default['selinux']['state'] = 'enforcing'
+default['selinux']['booleans'] = {}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,3 +20,18 @@ selinux_state "SELinux #{node['selinux']['state'].capitalize}" do
   action node['selinux']['state'].downcase.to_sym
 end
 
+node['selinux']['booleans'].each do |boolean, value|
+  if ['on', 'true', '1'].include? value
+    value = 'on'
+  elsif ['off', 'false', '0'].include? value
+    value = 'off'
+  else
+    Chef::Log.warn "Not a valid boolean value: #{value}"
+    next
+  end
+  script "boolean_#{boolean}" do
+    interpreter "bash"
+    code "setsebool -P #{boolean} #{value}"
+    not_if "getsebool #{boolean} |egrep -q \" #{value}\"$"
+  end
+end


### PR DESCRIPTION
Support setting of SELinux boolean values via the setsebool command. This functionality is useful to, e.g. set boolean_httpd_can_network_connect_db for PHP web servers.

See https://tickets.opscode.com/browse/COOK-4218
