### PR TITLE
COOK-4562 Basic Ubuntu support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
-.idea


### PR DESCRIPTION
This patch allows selinux::disable to work on Ubuntu
See https://tickets.opscode.com/browse/COOK-4562
