### PR TITLE
Chomp stdout in load current resources.

### DIFF
--- a/providers/state.rb
+++ b/providers/state.rb
@@ -56,7 +56,7 @@ end
 def load_current_resource
   @current_resource = Chef::Resource::SelinuxState.new(new_resource.name)
   s = shell_out("getenforce")
-  @current_resource.state(s.stdout.downcase)
+  @current_resource.state(s.stdout.chomp.downcase)
 end
 
 def render_selinux_template(state)


### PR DESCRIPTION
The value extracted from stdout may have \n.  The effect is to
make every run of the provider non-idempotent.
