### PR TITLE
Add serverspec integration tests, update supported platforms

### DIFF
--- a/.kitchen.local.yml.example
+++ b/.kitchen.local.yml.example
@@ -1,0 +1,20 @@
+# https://lists.debian.org/debian-user/2015/05/msg00420.html
+# no debian support 8 at this time
+platforms:
+- name: centos-5.11
+- name: centos-6.7
+- name: centos-7.2
+- name: debian-7.9
+- name: fedora-22
+- name: fedora-23
+
+suites:
+- name: disabled
+  attributes: { "selinux": { "state": "disabled" } }
+  run_list: [ 'recipe[selinux]', 'recipe[export-node]' ]
+- name: permissive
+  attributes: { "selinux": { "state": "permissive" } }
+  run_list: [ 'recipe[selinux]', 'recipe[export-node]' ]
+- name: enforcing
+  attributes: { "selinux": { "state": "enforcing" } }
+  run_list: [ 'recipe[selinux]', 'recipe[export-node]' ]

--- a/.kitchen.local.yml.example
+++ b/.kitchen.local.yml.example
@@ -1,5 +1,5 @@
 # https://lists.debian.org/debian-user/2015/05/msg00420.html
-# no debian support 8 at this time
+# no debian 8 support at this time
 platforms:
 - name: centos-5.11
 - name: centos-6.7

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,15 +3,20 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: latest
 
+# https://lists.debian.org/debian-user/2015/05/msg00420.html
+# no debian support 8 at this time
 platforms:
-- name: centos-6.5
-- name: centos-5.10
-- name: fedora-19
-- name: fedora-20
+- name: centos-5.11
+- name: centos-6.7
+- name: centos-7.2
+- name: debian-7.9
+  attributes: { "selinux": { "state": "disabled" } }
+- name: fedora-22
+- name: fedora-23
 
 suites:
 - name: default
-  run_list: ["recipe[selinux]"]
-  attributes: {}
+  run_list:
+    - recipe[selinux]
+    - recipe[export-node]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,7 +5,7 @@ provisioner:
   name: chef_zero
 
 # https://lists.debian.org/debian-user/2015/05/msg00420.html
-# no debian support 8 at this time
+# no debian 8 support at this time
 platforms:
 - name: centos-5.11
 - name: centos-6.7

--- a/Berksfile
+++ b/Berksfile
@@ -2,4 +2,10 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'selinux_state_test', path: 'test/fixtures/cookbooks/selinux_state_test'
+cookbook 'apt'
+cookbook 'yum', '~> 3.9.0'
+
+group :integration do
+  cookbook 'selinux_state_test', path: 'test/fixtures/cookbooks/selinux_state_test'
+  cookbook 'export-node', path: 'test/fixtures/cookbooks/export-node'
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 selinux Cookbook CHANGELOG
 ==========================
 
+feature/add-serverspec
+-------------------
+- Add `node['selinux']['needs_reboot']` attribute to accommodate SELinux actions that require a reboot. Disabling SELinux on a permissive or enforcing host *or* enabling SELinux on a disabled host require a reboot.
+- Add serverspec tests
+- Add Centos 7 support
+- Update supported Fedora versions
+
+
 v0.9.0 (2015-02-22)
 -------------------
 - Initial Debian / Ubuntu support
@@ -24,7 +32,7 @@ v0.7.0 (2014-02-27)
 
 v0.6.2
 ------
-- Fixing bug introduced in 0.6.0 
+- Fixing bug introduced in 0.6.0
 - adding basic test-kitchen coverage
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ feature/add-serverspec
 - Add `node['selinux']['needs_reboot']` attribute to accommodate SELinux actions that require a reboot. Disabling SELinux on a permissive or enforcing host *or* enabling SELinux on a disabled host require a reboot.
 - Add serverspec tests
 - Add Centos 7 support
-- Update supported Fedora versions
+- Update supported Fedora/CentOS versions
+- Drop Ubuntu support
 
 
 v0.9.0 (2015-02-22)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,14 @@
 default['selinux']['booleans'] = {}
 default['selinux']['needs_reboot'] = nil
 default['selinux']['state'] = 'enforcing'
+
+case node['platform_family']
+when 'debian'
+  default['selinux']['packages'] = node['selinux']['state'] != 'disabled' ?
+    %w(selinux-utils selinux-policy-default selinux-basics auditd) :
+    %w(selinux-utils)
+when %r(fedora|rhel)
+  default['selinux']['packages'] = %w(libselinux-utils)
+else
+  raise "#{node['platform_family']} not supported!"
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
-default['selinux']['state'] = 'enforcing'
 default['selinux']['booleans'] = {}
+default['selinux']['needs_reboot'] = nil
+default['selinux']['state'] = 'enforcing'

--- a/metadata.rb
+++ b/metadata.rb
@@ -22,13 +22,12 @@ attribute "selinux/needs_reboot",
   :display_name => "Needs Reboot",
   :description => "SELinux state change requires node reboot.",
   :calculated => true,
-  :type => "boolean",
-  :default => "nil"
+  :type => "boolean"
 attribute "selinux/packages",
   :display_name => "Packages",
   :description => "Packages required by SELinux.",
   :calculated => true,
-  :type => "array",
+  :type => "array"
 attribute "selinux/state",
   :display_name => "SELinux State",
   :description => "The SELinux policy enforcement state.",

--- a/metadata.rb
+++ b/metadata.rb
@@ -22,3 +22,6 @@ attribute "selinux/state",
   :recipes => ["selinux::default"],
   :type => "string",
   :default => "enforcing"
+
+depends 'apt'
+depends 'yum', '~> 3.9.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,15 +6,29 @@ description      "Manages SELinux policy state via LWRP or recipes."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.9.0"
 
-%w{redhat centos scientific oracle amazon ubuntu debian}.each do |os|
-  supports os
-end
+supports 'redhat'
+supports 'centos'
+supports 'scientific'
+supports 'oracle'
+supports 'amazon'
+supports 'debian', '<= 8.0'
 
 recipe "selinux", "Use LWRP with state attribute to manage SELinux state."
 recipe "selinux::enforcing", "Use :enforcing as the action for the selinux_state."
 recipe "selinux::permissive", "Use :permissive as the action for the selinux_state."
 recipe "selinux::disabled", "Use :disabled as the action for the selinux_state."
 
+attribute "selinux/needs_reboot",
+  :display_name => "Needs Reboot",
+  :description => "SELinux state change requires node reboot.",
+  :calculated => true,
+  :type => "boolean",
+  :default => "nil"
+attribute "selinux/packages",
+  :display_name => "Packages",
+  :description => "Packages required by SELinux.",
+  :calculated => true,
+  :type => "array",
 attribute "selinux/state",
   :display_name => "SELinux State",
   :description => "The SELinux policy enforcement state.",

--- a/providers/state.rb
+++ b/providers/state.rb
@@ -65,7 +65,7 @@ end
 
 def load_current_resource
   @current_resource = Chef::Resource::SelinuxState.new(new_resource.name)
-  @current_resource.state(`getenforce`.strip.downcase)
+  @current_resource.state(Mixlib::ShellOut.new('getenforce').run_command.stdout.strip.downcase)
 end
 
 def render_selinux_template(state)

--- a/providers/state.rb
+++ b/providers/state.rb
@@ -19,27 +19,36 @@
 require 'chef/mixin/shell_out'
 include Chef::Mixin::ShellOut
 
+require 'tmpdir'
+
 def whyrun_supported?
   true
 end
 
+activate_persist = "#{Dir.tmpdir()}/selinux-activated"
+
 action :enforcing do
-  unless @current_resource.state == "enforcing"
-    execute "selinux-enforcing" do
-      not_if "getenforce | grep -qx 'Enforcing'"
-      command "setenforce 1"
+  unless ::File.exist?(activate_persist)
+    unless (@current_resource.state == "enforcing")
+      execute "selinux-enforcing" do
+        not_if "getenforce | grep -qx 'Enforcing'"
+        command "setenforce 1"
+      end
+      se_template = render_selinux_template("enforcing")
+      new_resource.updated_by_last_action(true)
     end
-    se_template = render_selinux_template("enforcing")
   end
 end
 
 action :disabled do
   unless @current_resource.state == "disabled"
     execute "selinux-disabled" do
-      only_if "selinuxenabled"
+      not_if "selinuxenabled"
       command "setenforce 0"
     end
+    node.default['selinux']['needs_reboot'] = true
     se_template = render_selinux_template("disabled")
+    new_resource.updated_by_last_action(true)
   end
 end
 
@@ -50,26 +59,39 @@ action :permissive do
       command "setenforce 0"
     end
     se_template = render_selinux_template("permissive")
+    new_resource.updated_by_last_action(true)
   end
 end
 
 def load_current_resource
   @current_resource = Chef::Resource::SelinuxState.new(new_resource.name)
-  s = shell_out("getenforce")
-  @current_resource.state(s.stdout.chomp.downcase)
+  @current_resource.state(`getenforce`.strip.downcase)
 end
 
 def render_selinux_template(state)
-  template "#{state} selinux config" do
-    path "/etc/selinux/config"
-    source "sysconfig/selinux.erb"
-    cookbook "selinux"
-    if state == 'permissive'
-      not_if "getenforce | grep -qx 'Disabled'"
+  # Debian hosts cannot execute restorecon against the template successfully
+  # Use FileEdit as a workaround
+  if platform_family?('debian')
+    selinux_config_file = Chef::Util::FileEdit.new('/etc/selinux/config')
+    ruby_block "write #{state} selinux config" do
+      block do
+        selinux_config_file.search_file_replace(/^SELINUX=(?!#{state}).*$/, "SELINUX=#{state}")
+        selinux_config_file.write_file
+      end
+      not_if { ::File.open('/etc/selinux/config').read =~ /^SELINUX=#{state}$/ }
     end
-    variables(
-      :selinux => state,
-      :selinuxtype => "targeted"
-    )
+  else
+    template "#{state} selinux config" do
+      path "/etc/selinux/config"
+      source "sysconfig/selinux.erb"
+      cookbook "selinux"
+      if state == 'permissive'
+        not_if "getenforce | grep -qx 'Disabled'"
+      end
+      variables(
+        :selinux => state,
+        :selinuxtype => "targeted"
+      )
+    end
   end
 end

--- a/providers/state.rb
+++ b/providers/state.rb
@@ -43,7 +43,7 @@ end
 action :disabled do
   unless @current_resource.state == "disabled"
     execute "selinux-disabled" do
-      not_if "selinuxenabled"
+      only_if "selinuxenabled"
       command "setenforce 0"
     end
     node.default['selinux']['needs_reboot'] = true

--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -1,17 +1,30 @@
 
-case node[:platform_family]
+case node['platform_family']
 when %r(debian|ubuntu)
-  package 'selinux-utils'
-when 'rhel', 'fedora'
+  include_recipe 'apt'
+  if node['platform_version'].to_f <= 12
+    %w(selinux-utils selinux-policy-default selinux-basics auditd).each { |pkg|
+      package pkg
+    }
+  elsif
+    %w(selinux selinux-utils selinux-policy-ubuntu selinux-basics auditd).each { |pkg|
+      package pkg if node['selinux']['state'] == 'enabled'
+    }
+  end
+  include_recipe 'selinux::debian'
+when %r(fedora|rhel)
+  if node['platform_version'].to_f >= 7.0
+    include_recipe 'yum::dnf_yum_compat'
+  end
   package 'libselinux-utils'
 else
     # implement support for your platform here!
-    raise "#{node[:platform_family]} not supported!"
+    raise "#{node['platform_family']} not supported!"
 end
 
 directory '/etc/selinux' do
   owner 'root'
   group 'root'
   mode '0755'
-  action :create
+  action if node['selinux']['state'] == 'disabled' ? :nothing : :create
 end

--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -1,30 +1,10 @@
-
 case node['platform_family']
-when %r(debian|ubuntu)
+when 'debian'
   include_recipe 'apt'
-  if node['platform_version'].to_f <= 12
-    %w(selinux-utils selinux-policy-default selinux-basics auditd).each { |pkg|
-      package pkg
-    }
-  elsif
-    %w(selinux selinux-utils selinux-policy-ubuntu selinux-basics auditd).each { |pkg|
-      package pkg if node['selinux']['state'] == 'enabled'
-    }
-  end
-  include_recipe 'selinux::debian'
 when %r(fedora|rhel)
-  if node['platform_version'].to_f >= 7.0
-    include_recipe 'yum::dnf_yum_compat'
-  end
-  package 'libselinux-utils'
-else
-    # implement support for your platform here!
-    raise "#{node['platform_family']} not supported!"
+  include_recipe 'yum::dnf_yum_compat'
 end
 
-directory '/etc/selinux' do
-  owner 'root'
-  group 'root'
-  mode '0755'
-  action if node['selinux']['state'] == 'disabled' ? :nothing : :create
-end
+package node['selinux']['packages']
+
+include_recipe 'selinux::debian' if platform_family?('debian')

--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -5,6 +5,8 @@ when %r(fedora|rhel)
   include_recipe 'yum::dnf_yum_compat'
 end
 
-package node['selinux']['packages']
+node['selinux']['packages'].each { |pkg|
+  package pkg
+}
 
 include_recipe 'selinux::debian' if platform_family?('debian')

--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -1,0 +1,30 @@
+require 'tmpdir'
+
+activate_persist = "#{Dir.tmpdir()}/selinux-activated"
+
+unless node['selinux']['state'] == 'disabled'
+  # first:  set true, activate
+  # next:   no action (unless)
+  # after:  no action (only_if)
+  ruby_block 'selinux-activate' do
+    block do
+      unless ::File.exist?(activate_persist)
+        `selinux-activate 2>&1 | tee #{activate_persist}`
+        node.force_default['selinux']['needs_reboot'] = true
+      end
+    end
+    Chef::Log.warn "#{node['hostname']} must reboot to fully enable SELinux!"
+    only_if "check-selinux-installation | grep -qx 'SELinux is not enabled.'"
+  end
+end
+
+desired_action =
+node['selinux']['state'] == 'disabled' ?
+  [ :disable, :stop ] :
+  [ :enable, :start ]
+
+service 'selinux-basics' do
+  status_command 'test -x /sys/fs/selinux'
+  supports :restart => true
+  action %w(node['selinix']['needs_reboot']) ? :nothing : desired_action
+end

--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -9,8 +9,11 @@ unless node['selinux']['state'] == 'disabled'
   ruby_block 'selinux-activate' do
     block do
       unless ::File.exist?(activate_persist)
-        `selinux-activate 2>&1 | tee #{activate_persist}`
-        node.force_default['selinux']['needs_reboot'] = true
+        activate_cmd = Mixlib::ShellOut.
+          new("selinux-activate 2>&1 | tee #{activate_persist}")
+        activate_cmd.run_command
+        activate_cmd.error!
+        node.default['selinux']['needs_reboot'] = true
       end
     end
     Chef::Log.warn "#{node['hostname']} must reboot to fully enable SELinux!"

--- a/spec/selinux_state_spec.rb
+++ b/spec/selinux_state_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 describe 'selinux_state_test::default' do
 
   cached(:chef_run) do
-    ChefSpec::SoloRunner.new.converge(described_recipe)
+    ChefSpec::SoloRunner.
+      new(platform: 'centos', version: 7.0).
+      converge(described_recipe)
   end
 
   it 'enforcing selinux' do

--- a/test/fixtures/cookbooks/export-node/metadata.rb
+++ b/test/fixtures/cookbooks/export-node/metadata.rb
@@ -1,0 +1,2 @@
+name 'export-node'
+version '0.0.1'

--- a/test/fixtures/cookbooks/export-node/recipes/default.rb
+++ b/test/fixtures/cookbooks/export-node/recipes/default.rb
@@ -1,0 +1,7 @@
+ruby_block 'Save node attributes' do
+  block do
+    if Dir::exist?('/tmp/kitchen')
+      IO.write('/tmp/kitchen/chef_node.json', node.to_hash.to_json)
+    end
+  end
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require_relative '../serverspec/shared_serverspec_tests/selinux.rb'
+
+describe "selinux #{$node['selinux']['state']}" do
+  include_examples 'selinux'
+end

--- a/test/integration/disabled/serverspec/disabled_spec.rb
+++ b/test/integration/disabled/serverspec/disabled_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require_relative '../serverspec/shared_serverspec_tests/selinux.rb'
+
+describe "selinux #{$node['selinux']['state']}" do
+  include_examples 'selinux'
+end

--- a/test/integration/enforcing/serverspec/enforcing_spec.rb
+++ b/test/integration/enforcing/serverspec/enforcing_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require_relative '../serverspec/shared_serverspec_tests/selinux.rb'
+
+describe "selinux #{$node['selinux']['state']}" do
+  include_examples 'selinux'
+end

--- a/test/integration/helpers/serverspec/shared_serverspec_tests/selinux.rb
+++ b/test/integration/helpers/serverspec/shared_serverspec_tests/selinux.rb
@@ -2,19 +2,11 @@ require 'rspec'
 require 'spec_helper'
 
 RSpec.shared_examples 'selinux' do
-  describe file('/etc/selinux/config') do
-    it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
-  end
-
   describe command("/usr/sbin/getenforce") do
     if $node['selinux']['needs_reboot']
       desired = Regexp.new(/^(Disabled|Permissive)$/)
     else
       desired = Regexp.new($node['selinux']['state'].capitalize)
-      # desired = $node['selinux']['state'] == 'enforcing' ?
-      #   Regexp.new($node['selinux']['state'].capitalize) :
-      #   Regexp.new(/^(Disabled|Permissive)$/)
     end
     its(:exit_status) { should eq 0 }
     its(:stdout) { should match(desired) }

--- a/test/integration/helpers/serverspec/shared_serverspec_tests/selinux.rb
+++ b/test/integration/helpers/serverspec/shared_serverspec_tests/selinux.rb
@@ -1,0 +1,22 @@
+require 'rspec'
+require 'spec_helper'
+
+RSpec.shared_examples 'selinux' do
+  describe file('/etc/selinux/config') do
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+  end
+
+  describe command("/usr/sbin/getenforce") do
+    if $node['selinux']['needs_reboot']
+      desired = Regexp.new(/^(Disabled|Permissive)$/)
+    else
+      desired = Regexp.new($node['selinux']['state'].capitalize)
+      # desired = $node['selinux']['state'] == 'enforcing' ?
+      #   Regexp.new($node['selinux']['state'].capitalize) :
+      #   Regexp.new(/^(Disabled|Permissive)$/)
+    end
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match(desired) }
+  end
+end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,6 @@
+require 'serverspec'
+require 'json'
+
+set :backend, :exec
+
+$node = ::JSON.parse(File.read('/tmp/kitchen/chef_node.json'))

--- a/test/integration/permissive/serverspec/permissive_spec.rb
+++ b/test/integration/permissive/serverspec/permissive_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require_relative '../serverspec/shared_serverspec_tests/selinux.rb'
+
+describe "selinux #{$node['selinux']['state']}" do
+  include_examples 'selinux'
+end


### PR DESCRIPTION
- Add `node['selinux']['needs_reboot']` attribute to accommodate SELinux actions that require a reboot.
- Add serverspec tests
- Add Centos 7 support
- Update supported Fedora/CentOS versions
- Drop Ubuntu support
