### PR TITLE
Update metadata to require chef 12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 selinux Cookbook CHANGELOG
 ==========================
 
+## 1.0.3 (2017-03-14)
+
+- Fix requirement in metadata to reflect need for Chef 12.7 as using action_class in state resource.
+
 ## 1.0.2 (2017-03-01)
 
 - Remove setools* packages from install resource (utility to analyze and query policies, monitor and report audit logs, and manage file context). Future versions of this cookbook that might use this need to handle package install on Oracle Linux as not available in default repo.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Disable SELinux only if you plan to not use it. Use `Permissive` mode if you jus
 
 ## Requirements
 
-- Chef 12.5 or higher
+- Chef 12.7 or higher
 
 
 ## Platform:

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license          'Apache'
 description      'Manages SELinux policy state'
-version          '1.0.2'
+version          '1.0.3'
 
 %w(redhat centos scientific oracle amazon fedora).each do |os|
   supports os
@@ -11,4 +11,4 @@ end
 
 source_url 'https://github.com/chef-cookbooks/selinux'
 issues_url 'https://github.com/chef-cookbooks/selinux/issues'
-chef_version '>= 12.5'
+chef_version '>= 12.7'


### PR DESCRIPTION

### Description

Resolve Issue #33. action_class not available in pre Chef-12.7.
Signed-off-by: Jennifer Davis <iennae@gmail.com>

### Issues Resolved

Issue #33

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
