### PR TITLE
Deprecate debian family support

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -13,6 +13,7 @@ provisioner:
 verifier:
   name: inspec
 
+platforms: 
 - name: centos-6
   driver:
     image: centos:6

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -13,23 +13,6 @@ provisioner:
 verifier:
   name: inspec
 
-platforms:
-- name: debian-7
-  driver:
-    image: debian:7
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
-
-- name: debian-8
-  driver:
-    image: debian:8
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
-
 - name: centos-6
   driver:
     image: centos:6
@@ -52,19 +35,3 @@ platforms:
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
       - RUN dnf -y install which systemd-sysv initscripts wget net-tools
-
-- name: ubuntu-14.04
-  driver:
-    image: ubuntu-upstart:14.04
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
-
-- name: ubuntu-16.04
-  driver:
-    image: ubuntu:16.04
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,11 +10,7 @@ verifier:
 platforms:
   - name: centos-6.8
   - name: centos-7.3
-  - name: debian-7.11
-  - name: debian-8.7
   - name: fedora-25
-  - name: ubuntu-14.04
-  - name: ubuntu-16.04
 
 suites:
 - name: default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # selinux Cookbook CHANGELOG
 This file is used to list changes made in each version of the selinux cookbook.
 
+## UNRELEASED
+
+- Deprecate debian family support 
+- Make default for rhel family use setenforce regardless of whether a temporary change or not. Eliminates the requirement for a required reboot to effect change in the running system.
+
 ## 1.0.4 (2017-04-17)
 
 - Switch to local delivery for testing

--- a/resources/state.rb
+++ b/resources/state.rb
@@ -26,7 +26,7 @@ action :enforcing do
   execute 'selinux-enforcing' do
     not_if "getenforce | egrep -qx 'Disabled'"
     command 'setenforce 1'
-  end 
+  end
 
   render_selinux_template('enforcing', new_resource.policy) unless new_resource.temporary
 end
@@ -40,7 +40,7 @@ action :permissive do
   execute 'selinux-permissive' do
     not_if "getenforce | egrep -qx 'Disabled'"
     command 'setenforce 0'
-  end 
+  end
 
   render_selinux_template('permissive', new_resource.policy) unless new_resource.temporary
 end

--- a/resources/state_debian.rb
+++ b/resources/state_debian.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 provides :selinux_state_debian
-provides :selinux_state, platform_family: 'debian' 
+provides :selinux_state, platform_family: 'debian'
 
 property :temporary, [true, false], default: false
 property :policy, String, default: 'targeted'
@@ -28,15 +28,12 @@ action :enforcing do
     not_if "getenforce | egrep -qx 'Disabled'"
     command 'setenforce 1'
   end if new_resource.temporary
-
   render_selinux_template('enforcing', new_resource.policy) unless new_resource.temporary
-
 end
 
 action :disabled do
   log 'Temporary changes to the running SELinux status is not possible when SELinux is disabled.' if new_resource.temporary
   render_selinux_template('disabled', new_resource.policy) unless new_resource.temporary
-
 end
 
 action :permissive do
@@ -44,9 +41,7 @@ action :permissive do
     not_if "getenforce | egrep -qx 'Disabled'"
     command 'setenforce 0'
   end if new_resource.temporary
-
   render_selinux_template('permissive', new_resource.policy) unless new_resource.temporary
-
 end
 
 action_class.class_eval do


### PR DESCRIPTION
### Description

Deprecate debian family support. 

Make default for rhel family use setenforce regardless of whether a temporary change or not. Eliminates the requirement for a required reboot to effect change in the running system. This means that debian family and rhel family operating systems will have different behaviors.

### Issues Resolved

Issue #45, #44 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
