### PR TITLE
Use correct guard for `execute 'selinux-permissive'` resource.

### DIFF
--- a/resources/state.rb
+++ b/resources/state.rb
@@ -38,7 +38,7 @@ end
 
 action :permissive do
   execute 'selinux-permissive' do
-    not_if "getenforce | egrep -qx 'Disabled'"
+    not_if "getenforce | egrep -qx 'Permissive'"
     command 'setenforce 0'
   end
 

--- a/resources/state.rb
+++ b/resources/state.rb
@@ -38,7 +38,7 @@ end
 
 action :permissive do
   execute 'selinux-permissive' do
-    not_if "getenforce | egrep -qx 'Permissive'"
+    not_if "getenforce | egrep -qx 'Disabled|Permissive'"
     command 'setenforce 0'
   end
 


### PR DESCRIPTION
The `execute 'selinux-permissive'` resource should guard currently checks for
`getenforce | egrep -qx 'Disabled'` but it should be checking for `Permissive`.


Use the correct guard for `execute 'selinux-permissive'` resource.


- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>