### PR TITLE
next unless value.nil? is not doing what is intended

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@ end
 
 node['selinux']['booleans'].each do |boolean, value|
   value = SELinuxServiceHelpers.selinux_bool(value)
-  next unless value.nil?
+  next if value.nil?
   script "boolean_#{boolean}" do
     interpreter 'bash'
     code "setsebool -P #{boolean} #{value}"


### PR DESCRIPTION
### Description

The syntax used for `next unless` is the opposite of what's needed. It needs to be `next if`. The next command jumps to the next iteration of the loop. It does not execute the "next" line.

The desired behavior is to skip to the next iteration of the loop if the user of the cookbook does not specify a value that can be converted to a valid boolean. The existing code is doing the opposite.

### Issues Resolved
https://github.com/chef-cookbooks/selinux/issues/48

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
