### PR TITLE
Do not execute setenforce 1 every time

### DIFF
--- a/resources/state.rb
+++ b/resources/state.rb
@@ -24,7 +24,7 @@ property :policy, String, default: 'targeted'
 action :enforcing do
   # check for temporary attribute. if temporary, and disabled log error
   execute 'selinux-enforcing' do
-    not_if "getenforce | egrep -qx 'Disabled'"
+    not_if "getenforce | egrep -qx 'Disabled|Enforcing'"
     command 'setenforce 1'
   end
 


### PR DESCRIPTION
When SELinux is set as Enforcing, every time chef-client runs "setenforce 1" gets executed again. It should do this only once as in the permissive action.
