### PR TITLE
fix selinux_module and broken CI builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ Disable SELinux only if you plan to not use it. Use `Permissive` mode if you jus
 
 ### selinux_state
 
-The `selinux_state` resource is used to manage the SELinux state on the system. It does this by using the `setenforce` command and rendering
-
-# the `/etc/selinux/config` file from a template.
+The `selinux_state` resource is used to manage the SELinux state on the system. It does this by using the `setenforce` command and rendering the `/etc/selinux/config` file from a template.
 
 ## selinux_module
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -9,6 +9,8 @@ transport:
 provisioner:
   name: dokken
   deprecations_as_errors: true
+  client_rb:
+    chef_license: accept
 
 verifier:
   name: inspec

--- a/libraries/selinux_file_helper.rb
+++ b/libraries/selinux_file_helper.rb
@@ -29,7 +29,7 @@ module SELinux
         line.chomp
 
         # extracting version and module name
-        if match = line.match(/^module\s+(\w+)\s+([\d\.\-]+);/)
+        if (match = line.match(/^module\s+(\w+)\s+([\d\.\-]+);/))
           @module_name, @version = match.captures
         end
 

--- a/libraries/selinux_module_helper.rb
+++ b/libraries/selinux_module_helper.rb
@@ -26,7 +26,7 @@ module SELinux
       installed_modules = {}
       exec_semodule_cmd.each_line do |line|
         line.chomp
-        if match = line.match(/^(\w+.*?)\s+((\d+\.)?(\d+\.)?(\*|\d+))/)
+        if (match = line.match(/^(\w+.*?)\s+((\d+\.)?(\d+\.)?(\*|\d+))/))
           module_name, version = match.captures
           installed_modules[module_name] = version
         end

--- a/spec/selinux_module_spec.rb
+++ b/spec/selinux_module_spec.rb
@@ -45,8 +45,7 @@ alsa       1.12.2
   end
 
   it 'installs the dependency packages' do # ~FC005
-    expect(chef_run).to(install_package('make'))
-    expect(chef_run).to(install_package('policycoreutils'))
+    expect(chef_run).to(install_package('make, policycoreutils, selinux-policy-devel'))
   end
 
   it 'logs the steps taken' do
@@ -86,7 +85,6 @@ describe 'selinux_module_test::remove' do
   end
 
   it 'removes the `test` selinux module' do
-    expect(chef_run).to(write_log(/Removing SELinux/))
     expect(chef_run).to(
       ChefSpec::Matchers::ResourceMatcher.new(
         :selinux_module, :remove, 'test'))

--- a/spec/selinux_state_spec.rb
+++ b/spec/selinux_state_spec.rb
@@ -23,15 +23,13 @@ describe 'selinux_state_test::default' do
       ChefSpec::Matchers::ResourceMatcher.new(
         :selinux_state, :enforcing, 'enforcing'))
     expect(chef_run).to(
-      run_execute('selinux-enforcing').with_command('setenforce 1'))
+      run_execute('selinux-enforcing').with_command('/usr/sbin/setenforce 1'))
   end
 
   it 'disabled selinux' do
     expect(chef_run).to(
       ChefSpec::Matchers::ResourceMatcher.new(
         :selinux_state, :disabled, 'disabled'))
-    expect(chef_run).to(
-      run_execute('selinux-disabled').with_command('setenforce 0'))
     expect(chef_run).to(
       ChefSpec::Matchers::ResourceMatcher.new(
         :template, :create, 'disabled selinux config'))
@@ -41,6 +39,8 @@ describe 'selinux_state_test::default' do
     expect(chef_run).to(
       ChefSpec::Matchers::ResourceMatcher.new(
         :selinux_state, :permissive, 'permissive'))
+    expect(chef_run).to(
+      run_execute('selinux-permissive').with_command('/usr/sbin/setenforce 0'))
     expect(chef_run).to(
       render_file('/etc/selinux/config'))
   end

--- a/test/fixtures/cookbooks/selinux_module_test/recipes/create.rb
+++ b/test/fixtures/cookbooks/selinux_module_test/recipes/create.rb
@@ -3,6 +3,7 @@
 #        Recipe:: create
 #
 
+selinux_install 'selinux os prep'
 selinux_module 'create' do
   source 'test.te'
   force true

--- a/test/fixtures/cookbooks/selinux_module_test/recipes/remove.rb
+++ b/test/fixtures/cookbooks/selinux_module_test/recipes/remove.rb
@@ -3,6 +3,7 @@
 #        Recipe:: remove
 #
 
+selinux_install 'selinux os prep'
 selinux_module 'test' do
   action :remove
 end


### PR DESCRIPTION
* accept chef_license in kitchen dokken client_rb
* added missing package `selinux-policy-devel` fixing `selinux_module`
* fixed `cookstyle`, `foodcritic`, unit and integration tests

Signed-off-by: Stefan Schwoegler <enkaskal@users.noreply.github.com>

### Description

Currently master is broken. This PR fixes `selinux_module` and the associated CI build failures.

### Issues Resolved

I didn't open an issue as it appears master has been broken for about a year now, but am happy to do so or rename the branch upon request.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] ~New functionality includes testing.~ N/A
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>