### PR TITLE
Fix attribute name to avoid Chef Infra Client 16 conflict

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,5 +18,6 @@
 #
 # this recipe will be deprecated in future releases
 
-default['selinux']['status'] = 'enforcing'
+default['selinux']['state'] = 'enforcing'
+default['selinux']['state'] = node['selinux']['status'] if node['selinux']['status']
 default['selinux']['booleans'] = {}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,8 +18,8 @@
 
 selinux_install 'selinux os prep'
 
-selinux_state "SELinux #{node['selinux']['status'].capitalize}" do
-  action node['selinux']['status'].downcase.to_sym
+selinux_state "SELinux #{node['selinux']['state'].capitalize}" do
+  action node['selinux']['state'].downcase.to_sym
 end
 
 node['selinux']['booleans'].each do |boolean, value|


### PR DESCRIPTION
The attribute name doesn't match what's in the README; this commit also tries
to maintain some backwards compatibility for those using the incorrect name. I
considered fixing the README instead but using `status` in place of `state`
feels wrong.'

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
