### PR TITLE
[GH-67] - Do not try to modify frozen checksum

### DIFF
--- a/resources/module.rb
+++ b/resources/module.rb
@@ -61,9 +61,9 @@ action :create do
                      end
   target_checksum = checksum(sefile_source_path)
 
-  log "Current checksum: '#{current_checksum.to_s.slice!(0..8)}' " \
+  log "Current checksum: '#{current_checksum.to_s.slice(0..8)}' " \
     "('#{sefile_target_path}')"
-  log "Target checksum: '#{target_checksum.to_s.slice!(0..8)}' " \
+  log "Target checksum: '#{target_checksum.to_s.slice(0..8)}' " \
     "('#{sefile_source_path}')"
 
   # checking if module is already installed


### PR DESCRIPTION
### Description
Use `slice` instead of `slice!` when logging the checksum string. Without this Chef will throw a FrozenError as per #67.

### Issues Resolved
#67 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>