### PR TITLE
fix(install): AL2023 install packages should match RHEL8+

### DIFF
--- a/libraries/install.rb
+++ b/libraries/install.rb
@@ -13,7 +13,12 @@ module SELinux
             %w(make policycoreutils policycoreutils-python-utils selinux-policy selinux-policy-targeted selinux-policy-devel libselinux-utils setools-console)
           end
         when 'amazon'
-          %w(make policycoreutils policycoreutils-python selinux-policy selinux-policy-targeted selinux-policy-devel libselinux-utils setools-console)
+          case node['platform_version'].to_i
+          when 2
+            %w(make policycoreutils policycoreutils-python selinux-policy selinux-policy-targeted selinux-policy-devel libselinux-utils setools-console)
+          else
+             %w(make policycoreutils policycoreutils-python-utils selinux-policy selinux-policy-targeted selinux-policy-devel libselinux-utils setools-console)
+          end
         when 'fedora'
           %w(make policycoreutils policycoreutils-python-utils selinux-policy selinux-policy-targeted selinux-policy-devel libselinux-utils setools-console)
         when 'debian'


### PR DESCRIPTION
# Description

This sets the default install packages for `selinux` on Amazon Linux 2023 to match those of the RHEL family 8+. Currently using `include_recipe 'selinux::permissive'` (for instance) gives the following error on AL 2023:

```
FATAL: Chef::Exceptions::Package: selinux_install[selinux] (selinux::permissive line 18) had an error: Chef::Exceptions::Package: dnf_package[selinux] (selinux::permissive line 34) had an error: Chef::Exceptions::Package: No candidate version available for policycoreutils-python
```

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
