### PR TITLE
chore: deprecate selinux cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file is used to list changes made in each version of the selinux cookbook.
 
+## Unreleased
+
+### Deprecations
+
+* Deprecated this cookbook because Chef Infra Client 18.0 and later include built-in `selinux_*` resources.
+* Direct future resource fixes to Chef Infra Client instead of maintaining duplicate resource implementations here.
+
 Standardise files with files in sous-chefs/repo-management
 Standardise files with files in sous-chefs/repo-management
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # SELinux Cookbook
 
+> [!IMPORTANT]
+> This cookbook is deprecated. Chef Infra Client 18.0 and later include built-in
+> `selinux_boolean`, `selinux_fcontext`, `selinux_install`, `selinux_login`,
+> `selinux_module`, `selinux_permissive`, `selinux_port`, `selinux_state`, and
+> `selinux_user` resources. New work should use those built-in Chef Infra Client
+> resources directly.
+>
+> Open functional reports against this cookbook, including fcontext built-in
+> override behavior, module reinstall behavior, module compilation behavior, and
+> Amazon Linux 2023 package defaults, affect resource behavior that is now owned
+> by Chef Infra Client. Please file follow-up fixes in
+> [chef/chef](https://github.com/chef/chef) instead of extending this deprecated
+> compatibility cookbook.
+
 [![Cookbook Version](https://img.shields.io/cookbook/v/selnux.svg)](https://supermarket.chef.io/cookbooks/selinux)
 [![CI State](https://github.com/sous-chefs/selinux/workflows/ci/badge.svg)](https://github.com/sous-chefs/selinux/actions?query=workflow%3Aci)
 [![OpenCollective](https://opencollective.com/sous-chefs/backers/badge.svg)](#backers)
@@ -8,7 +22,9 @@
 
 ## Description
 
-The SELinux (Security Enhanced Linux) cookbook provides recipes for manipulating SELinux policy enforcement state.
+The SELinux (Security Enhanced Linux) cookbook provided recipes and custom resources for manipulating SELinux policy enforcement state.
+
+This cookbook is retained only for existing Chef Infra Client 15-17 users that cannot yet move to Chef Infra Client 18 or later. It should not be added to new cookbooks.
 
 SELinux can have one of three settings:
 
@@ -30,6 +46,8 @@ Disable SELinux only if you plan to not use it. Use `Permissive` mode if you jus
 ## Requirements
 
 - Chef 15.3 or higher
+
+Chef Infra Client 18.0 and later provide the SELinux resources directly. Prefer the built-in resources on those releases.
 
 ## Platform
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,12 +2,17 @@ name             'selinux'
 maintainer       'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
-description      'Manages SELinux policy state and rules.'
+description      'Deprecated. Chef Infra Client 18+ includes built-in SELinux resources.'
 version          '6.2.5'
 source_url       'https://github.com/sous-chefs/selinux'
 issues_url       'https://github.com/sous-chefs/selinux/issues'
 chef_version     '>= 15.3'
 
-%w(redhat centos scientific oracle amazon fedora debian ubuntu).each do |os|
-  supports os
-end
+supports 'amazon'
+supports 'centos'
+supports 'debian'
+supports 'fedora'
+supports 'oracle'
+supports 'redhat'
+supports 'scientific'
+supports 'ubuntu'

--- a/resources/fcontext.rb
+++ b/resources/fcontext.rb
@@ -68,7 +68,7 @@ action_class do
              end
 
     # if path is not absolute, ignore it and search everything
-    common = '/' if common.first != '/'
+    common = '/' unless common.start_with?('/')
 
     if ::File.exist? common
       shell_out!("find #{common.shellescape} -ignore_readdir_race -regextype posix-egrep -regex #{spec.shellescape} -prune -print0 | xargs -0 restorecon -iRv")

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -2,7 +2,7 @@
 # Cookbook:: selinux
 # Resource:: install
 #
-# Copyright:: 2016-2025, Chef Software, Inc.
+# Copyright:: 2016-2026, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/module.rb
+++ b/resources/module.rb
@@ -2,7 +2,7 @@
 # Cookbook:: selinux
 # Resource:: module
 #
-# Copyright:: 2016-2025, Chef Software, Inc.
+# Copyright:: 2016-2026, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/state.rb
+++ b/resources/state.rb
@@ -2,7 +2,7 @@
 # Cookbook:: selinux
 # Resource:: state
 #
-# Copyright:: 2016-2025, Chef Software, Inc.
+# Copyright:: 2016-2026, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Deprecates the `selinux` cookbook because Chef Infra Client 18.0+ ships built-in `selinux_*` resources.
- Updates the README, metadata description, and changelog to direct new work to Chef Infra Client core.
- Notes that open functional reports should be fixed upstream in `chef/chef` rather than by extending the duplicate cookbook resources.
- Applies Cookstyle copyright-year autocorrections needed for the current toolchain.

## Open Issue Review

- Open issues reviewed before deprecation: #119 (`selinux_fcontext` built-in override behavior), #118 (`selinux_module` force reinstall), #114 (`selinux_module` compilation behavior), and PR #129 (Amazon Linux 2023 package defaults).
- Chef Infra Client 18.10 has built-in resource classes for `selinux_boolean`, `selinux_fcontext`, `selinux_install`, `selinux_login`, `selinux_module`, `selinux_permissive`, `selinux_port`, `selinux_state`, and `selinux_user`.
- The reviewed functional reports affect resource behavior now owned by Chef Infra Client, so they should be re-filed or fixed in `chef/chef` instead of keeping a Sous Chefs compatibility fork alive.

## Verification

- `cookstyle`: 52 files inspected, no offenses detected.
- `markdownlint-cli2 **/*.md #CHANGELOG.md`: 14 files, 0 errors.
- `git diff --check`: passed.
